### PR TITLE
docs: include ToastActivatedEventArgs import

### DIFF
--- a/docs/interactable.rst
+++ b/docs/interactable.rst
@@ -9,7 +9,7 @@ We import :class:`~windows_toasts.toasters.InteractableWindowsToaster` instead o
 
 .. code-block:: python
 
-    from windows_toasts import InteractableWindowsToaster, ToastButton, ToastText1
+    from windows_toasts import InteractableWindowsToaster, ToastActivatedEventArgs, ToastButton, ToastText1
 
     interactableToaster = InteractableWindowsToaster('Questionnaire')
     newToast = ToastText1()


### PR DESCRIPTION
Otherwise throws a NameError. Only used for typing but good to have for help() and IDEs.