### PR TITLE
refactor(toast)!: simplify toast configuration

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,7 @@ Major
 -----
 - Replaced winsdk requirement with toasts-winrt (#78)
 - Removed toast templates in favour of ToastGeneric (#75)
+- Simplified configuration of toasts (#82)
 
 Minor
 -----

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -27,7 +27,7 @@ Lets try out displaying an image
 Open a website on click
 -----------------------
 
-We use :meth:`windows_toasts.toast.Toast.launch_action` to open a website when the notification is pressed.
+We use :attr:`windows_toasts.toast.Toast.launch_action` to open a website when the notification is pressed.
 
 .. code-block:: python
 
@@ -125,7 +125,7 @@ Since Windows 10, you could always replace a notification by sending a new toast
       - Can completely change all content/layout of the toast
       - Can only change progress bar and top-level text
     * - **Reappearing as popup**
-      - Can reappear as a toast popup if you leave :meth:`~windows_toasts.toast.Toast.suppress_popup` set to false (or set to true to silently send it to Action Center)
+      - Can reappear as a toast popup if you leave :attr:`~windows_toasts.toast.Toast.suppress_popup` set to false (or set to true to silently send it to Action Center)
       - Won't reappear as a popup; the toast's data is silently updated within Action Center
     * - **User dismissed**
       - Regardless of whether user dismissed your previous notification, your replacement toast will always be sent

--- a/docs/advanced_usage.rst
+++ b/docs/advanced_usage.rst
@@ -15,7 +15,7 @@ Lets try out displaying an image
     toaster = WindowsToaster('Windows-Toasts')
 
     newToast = Toast()
-    newToast.SetFirstLine('<--- look, the Windows logo!')
+    newToast.text_fields = ['<--- look, the Windows logo!']
     # str or PathLike
     newToast.AddImage(ToastDisplayImage.fromPath('C:/Windows/System32/@WLOGO_96x96.png'))
 
@@ -27,19 +27,18 @@ Lets try out displaying an image
 Open a website on click
 -----------------------
 
-We use :meth:`windows_toasts.toast.Toast.SetLaunchAction` to open a website when the notification is pressed.
+We use :meth:`windows_toasts.toast.Toast.launch_action` to open a website when the notification is pressed.
 
 .. code-block:: python
 
-    import webbrowser
     from windows_toasts import Toast, WindowsToaster
 
     toaster = WindowsToaster('Rick Astley')
 
     newToast = Toast()
-    newToast.SetFirstLine('Hello there! You just won a thousand dollars! Click me to claim it!')
+    newToast.text_fields = ['Hello there! You just won a thousand dollars! Click me to claim it!']
     # Inline lambda function. This could also be an actual function
-    newToast.SetLaunchAction('https://www.youtube.com/watch?v=dQw4w9WgXcQ')
+    newToast.launch_action = 'https://www.youtube.com/watch?v=dQw4w9WgXcQ'
 
     # Send it
     toaster.show_toast(newToast)
@@ -57,8 +56,8 @@ There is a list of available, out-of-the-box audio sources at :class:`windows_to
     toaster = WindowsToaster('Windows-Toasts')
 
     newToast = Toast()
-    newToast.SetFirstLine('Ding ding! Ding ding! Ding ding!')
-    newToast.SetAudio(ToastAudio(AudioSource.IM, looping=True))
+    newToast.text_fields = ['Ding ding! Ding ding! Ding ding!']
+    newToast.audio = ToastAudio(AudioSource.IM, looping=True)
 
     toaster.show_toast(newToast)
 
@@ -92,21 +91,20 @@ You can dynamically modify a toast's progress bar or text field
 
     toaster = InteractableWindowsToaster('Python')
 
-    newToast = Toast()
-    newToast.SetFirstLine('Starting.')
+    newToast = Toast(['Starting.'])
     progressBar = ToastProgressBar('Waiting...', progress=0)
-    newToast.SetProgressBar(progressBar)
+    newToast.progress_bar = progressBar
 
     toaster.show_toast(newToast)
 
     for i in range(1, 11):
         time.sleep(1)
         progressBar.progress += 0.1
-        newToast.SetFirstLine(f'Stage {i}')
+        newToast.text_fields = [f'Stage {i}']
 
         toaster.update_toast(newToast)
 
-    newToast.SetFirstLine('Goodbye!')
+    newToast.text_fields = ['Goodbye!']
 
     toaster.update_toast(newToast)
 
@@ -127,7 +125,7 @@ Since Windows 10, you could always replace a notification by sending a new toast
       - Can completely change all content/layout of the toast
       - Can only change progress bar and top-level text
     * - **Reappearing as popup**
-      - Can reappear as a toast popup if you leave :meth:`~windows_toasts.toast.Toast.SetSuppressPopup` set to false (or set to true to silently send it to Action Center)
+      - Can reappear as a toast popup if you leave :meth:`~windows_toasts.toast.Toast.suppress_popup` set to false (or set to true to silently send it to Action Center)
       - Won't reappear as a popup; the toast's data is silently updated within Action Center
     * - **User dismissed**
       - Regardless of whether user dismissed your previous notification, your replacement toast will always be sent
@@ -146,7 +144,7 @@ You can also schedule a toast to display at a specified time
     toaster = WindowsToaster('Python')
 
     displayTime = datetime.now() + timedelta(seconds=10)
-    newToast = Toast(first_line=f'This will pop up at {displayTime}')
+    newToast = Toast([f'This will pop up at {displayTime}'])
 
     toaster.schedule_toast(newToast, displayTime)
 

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -45,6 +45,6 @@ To display a toast notification:
     # Initialise the toast
     newToast = Toast()
     # Set the body of the notification
-    newToast.SetFirstLine('Hello, World!')
+    newToast.text_fields = ['Hello, World!']
     # And display it!
     toaster.show_toast(newToast)

--- a/docs/interactable.rst
+++ b/docs/interactable.rst
@@ -12,9 +12,8 @@ We import :class:`~windows_toasts.toasters.InteractableWindowsToaster` instead o
     from windows_toasts import InteractableWindowsToaster, ToastActivatedEventArgs, ToastButton, ToastText1
 
     interactableToaster = InteractableWindowsToaster('Questionnaire')
-    newToast = ToastText1()
+    newToast = ToastText1(['How are you?'])
 
-    newToast.SetBody('How are you?')
     # Add two actions (buttons)
     newToast.AddAction(ToastButton('Decent', 'response=decent'))
     newToast.AddAction(ToastButton('Not so good', 'response=bad'))
@@ -44,7 +43,7 @@ Windows-Toasts also supports using text fields and selection boxes.
     from windows_toasts import InteractableWindowsToaster, ToastInputTextBox, ToastInputSelectionBox, ToastSelection, ToastText1
 
     interactableToaster = InteractableWindowsToaster('Questionnaire')
-    newToast = ToastText1(body='Please enter your details')
+    newToast = ToastText1(['Please enter your details'])
 
     # A text input field asking the user for their name
     newToast.AddInput(ToastInputTextBox('name', 'Your name', 'Barack Obama'))
@@ -75,7 +74,7 @@ We can combine the two and a submit button
     interactableToaster = InteractableWindowsToaster('Questionnaire')
     newToast = ToastText1()
 
-    newToast.SetBody('What\'s your name?')
+    newToast.text_fields = ['What\'s your name?']
     newToast.AddInput(ToastInputTextBox('name', 'Your name', 'Barack Obama'))
     newToast.AddAction(ToastButton('Submit', 'submit'))
     newToast.on_activated = lambda activatedEventArgs: print(activatedEventArgs.input)

--- a/docs/user/toast.rst
+++ b/docs/user/toast.rst
@@ -21,10 +21,5 @@ API
     :exclude-members: Toast, ToastInput
 
     .. autoclass:: windows_toasts.toast.Toast()
-        :exclude-members: audio, duration, scenario, textFields, timestamp, progress_bar, group, expiration_time,
-                          suppress_popup, actions, images, inputs
-
-        ..
-            As this is the ''user'' reference, we skip all the internal use attributes. This may be changes in the future.
 
         .. automethod:: __init__

--- a/src/windows_toasts/toast.py
+++ b/src/windows_toasts/toast.py
@@ -5,7 +5,8 @@ import datetime
 import urllib.parse
 import uuid
 import warnings
-from typing import Callable, Iterable, List, Literal, Optional, TypeVar
+from collections.abc import Iterable
+from typing import Callable, Literal, Optional, TypeVar, Union
 
 from toasts_winrt.windows.ui.notifications import ToastDismissedEventArgs, ToastFailedEventArgs
 
@@ -25,134 +26,86 @@ ToastInput = TypeVar("ToastInput", ToastInputTextBox, ToastInputSelectionBox)
 
 
 class Toast:
-    """
-    Base class for a toast. Should not be directly created or used as there are specific SetX() methods for it
-    """
-
     audio: Optional[ToastAudio]
-    """Audio configuration"""
-    actions: List[ToastButton]
-    """List of buttons to include. Implemented through :func:`AddAction`"""
+    """The custom audio configuration for the toast"""
     duration: Literal[ToastDuration.Default, ToastDuration.Long, ToastDuration.Short]
-    """:class:`~windows_toasts.wrappers.ToastDuration` enum, be it the default, short, or long"""
-    images: List[ToastDisplayImage]
-    """See :func:`AddImage`"""
+    """:class:`~windows_toasts.wrappers.ToastDuration`, be it the default, short, or long"""
+    expiration_time: Optional[datetime.datetime]
+    """The time for the toast to expire on in the action center. If it is on-screen, nothing will happen"""
+    group: Optional[str]
+    """A generic identifier, where you can assign groups like "wallPosts", "messages", "friendRequests", etc."""
     scenario: ToastScenario
     """Scenario for the toast"""
-    textFields: List[Optional[str]]
-    """Various text fields (dependant on subclass)"""
-    inputs: List[ToastInput]
-    """Placeholder for a text input box"""
-    timestamp: Optional[datetime.datetime]
-    """See :func:`SetCustomTimestamp`"""
-    progress_bar: Optional[ToastProgressBar] = None
-    """See :func:`SetProgressBar`"""
-    group: Optional[str] = None
-    """Group to place the toast in"""
-    tag: str
-    """uuid of a tag for the toast"""
-    updates: int
-    """Number of times the toast has been updated"""
-    expiration_time: Optional[datetime.datetime] = None
-    """Expiration time of the toast"""
-    suppress_popup: bool = False
+    suppress_popup: bool
     """Whether to suppress the toast popup and relegate it immediately to the action center"""
-    launch_action: Optional[str] = None
-    """Protocol to launch when the toast is clicked"""
+    timestamp: Optional[datetime.datetime]
+    """A custom timestamp. If you don't provide one, Windows uses the time that your notification was sent"""
+    progress_bar: Optional[ToastProgressBar]
+    """An adjustable progress bar for the toast"""
     on_activated: Optional[Callable[[ToastActivatedEventArgs], None]]
     """Callable to execute when the toast is clicked if basic, or a button is clicked if interactable"""
     on_dismissed: Optional[Callable[[ToastDismissedEventArgs], None]]
     """Callable to execute when the toast is dismissed (X is clicked or times out) if interactable"""
     on_failed: Optional[Callable[[ToastFailedEventArgs], None]]
     """Callable to execute when the toast fails to display"""
+    actions: list[ToastButton]
+    """List of buttons to include. Implemented through :func:`AddAction`"""
+    images: list[ToastDisplayImage]
+    """See :func:`AddImage`"""
+    inputs: list[ToastInput]
+    """Text/selection input boxes"""
+    text_fields: list[Optional[str]]
+    """Various text fields"""
+    tag: str
+    """uuid of a tag for the toast"""
+    updates: int
+    """Number of times the toast has been updated; mostly for internal use"""
+    _launch_action: Optional[str]
+    """Protocol to launch when the toast is clicked"""
 
     def __init__(
         self,
-        first_line: Optional[str] = None,
+        text_fields: Union[list[Optional[str]], tuple[Optional[str]], set[Optional[str]]] = None,
         audio: Optional[ToastAudio] = None,
-        actions: Iterable[ToastButton] = (),
         duration: ToastDuration = ToastDuration.Default,
-        scenario: ToastScenario = ToastScenario.Default,
-        progress_bar: Optional[ToastProgressBar] = None,
-        second_line: Optional[str] = None,
-        third_line: Optional[str] = None,
-        images: Iterable[ToastDisplayImage] = (),
-        inputs: Iterable[ToastInput] = (),
-        timestamp: Optional[datetime.datetime] = None,
-        group: Optional[str] = None,
         expiration_time: Optional[datetime.datetime] = None,
-        suppress_popup: bool = False,
+        group: Optional[str] = None,
         launch_action: Optional[str] = None,
+        progress_bar: Optional[ToastProgressBar] = None,
+        scenario: ToastScenario = ToastScenario.Default,
+        suppress_popup: bool = False,
+        timestamp: Optional[datetime.datetime] = None,
         on_activated: Optional[Callable[[ToastActivatedEventArgs], None]] = None,
         on_dismissed: Optional[Callable[[ToastDismissedEventArgs], None]] = None,
         on_failed: Optional[Callable[[ToastFailedEventArgs], None]] = None,
+        actions: Iterable[ToastButton] = (),
+        images: Iterable[ToastDisplayImage] = (),
+        inputs: Iterable[ToastInput] = (),
     ) -> None:
         """
         Initialise a toast
 
-        :param audio: See :meth:`SetAudio`
-        :type audio: Optional[ToastAudio]
         :param actions: Iterable of actions to add; see :meth:`AddAction`
         :type actions: Iterable[ToastButton]
-        :param duration: See :meth:`SetDuration`
-        :type duration: ToastDuration
-        :param scenario: See :meth:`SetScenario`
-        :type scenario: ToastScenario
-        :param progress_bar: See :meth:`SetProgressBar`
-        :type progress_bar: Optional[ToastProgressBar]
-        :param first_line: See :meth:`SetFirstLine`
-        :type first_line: Optional[str]
-        :param second_line: See :meth:`SetSecondLine`
-        :type second_line: Optional[str]
-        :param third_line: See :meth:`SetThirdLine`
-        :type third_line: Optional[str]
         :param images: See :meth:`AddImage`
         :type images: Iterable[ToastDisplayImage]
         :param inputs: See :meth:`AddInput`
         :type inputs: Iterable[ToastInput]
-        :param timestamp: See :meth:`SetCustomTimestamp`
-        :type timestamp: Optional[datetime.datetime]
-        :param group: See :meth:`SetGroup`
-        :type group: Optional[str]
-        :param expiration_time: See :meth:`SetExpirationTime`
-        :type expiration_time: Optional[datetime.datetime]
-        :param suppress_popup: See :meth:`SetSuppressPopup`
-        :type suppress_popup: bool
-        :param launch_action: See :meth:`SetLaunchAction`
-        :type launch_action: Optional[str]
-        :param on_activated: Callable to execute when the toast is clicked if basic, or a button is clicked if \
-         interactable
-        :type on_activated: Optional[Callable[[ToastActivatedEventArgs], None]]
-        :param on_dismissed: Callable to execute when the toast is dismissed (X is clicked or times out) if interactable
-        :type on_dismissed: Optional[Callable[[ToastDismissedEventArgs], None]]
-        :param on_failed: Callable to execute when the toast fails to display
-        :type on_failed:  Optional[Callable[[ToastFailedEventArgs], None]]
         """
+        self.audio = audio
+        self.duration = duration
+        self.scenario = scenario
+        self.progress_bar = progress_bar
+        self.timestamp = timestamp
+        self.group = group
+        self.expiration_time = expiration_time
+        self.suppress_popup = suppress_popup
+        self.launch_action = launch_action
+
         self.actions = []
-        self.inputs = []
         self.images = []
-        # Maximum of three text fields (at least until groups are implemented)
-        self.textFields = [None, None, None]
-
-        self.SetAudio(audio)
-        self.SetDuration(duration)
-        self.SetScenario(scenario)
-        self.SetCustomTimestamp(timestamp)
-        self.SetGroup(group)
-        self.SetProgressBar(progress_bar)
-        self.SetExpirationTime(expiration_time)
-        self.SetSuppressPopup(suppress_popup)
-        self.SetLaunchAction(launch_action)
-
-        # Certainly not the best way to do this now we've moved away from templates. Maybe expose textFields further?
-        # The behaviour of only exposing Add[Image/Input] without having an easy way to remove it is poor convention
-        # that I want to remove ASAP
-        if first_line is not None:
-            self.SetFirstLine(first_line)
-        if second_line is not None:
-            self.SetSecondLine(second_line)
-        if third_line is not None:
-            self.SetThirdLine(third_line)
+        self.inputs = []
+        self.text_fields = [] if text_fields is None else list(text_fields)
 
         for action in actions:
             self.AddAction(action)
@@ -179,55 +132,6 @@ class Toast:
     def __repr__(self):
         kws = [f"{key}={value!r}" for key, value in self.__dict__.items()]
         return "{}({})".format(type(self).__name__, ", ".join(kws))
-
-    def SetAudio(self, audio: Optional[ToastAudio]) -> None:
-        """
-        Sets the custom audio configuration for the toast
-        """
-        self.audio = audio
-
-    def SetDuration(self, duration: ToastDuration) -> None:
-        """
-        Set the display duration for the toast
-        """
-        self.duration = duration
-
-    def SetScenario(self, scenario: ToastScenario) -> None:
-        """
-        Set whether Windows should consider the notification as important
-        """
-        self.scenario = scenario
-
-    def SetProgressBar(self, progressBar: Optional[ToastProgressBar]) -> None:
-        """
-        Set a adjustable progress bar for the toast
-        """
-        self.progress_bar = progressBar
-
-    def SetGroup(self, group: Optional[str]) -> None:
-        """
-        Set a group for the toast. Group is a generic identifier, where you can assign groups like \
-        "wallPosts", "messages", "friendRequests", etc.
-        """
-        self.group = group
-
-    def SetFirstLine(self, lineText: str) -> None:
-        """
-        Sets the that will be displayed in the first line of a toast
-        """
-        self.textFields[0] = lineText
-
-    def SetSecondLine(self, lineText: str) -> None:
-        """
-        Sets the text that will be displayed in the second line of a toast
-        """
-        self.textFields[1] = lineText
-
-    def SetThirdLine(self, lineText: str) -> None:
-        """
-        Sets the text that will be displayed in the third line of a toast
-        """
-        self.textFields[2] = lineText
 
     def AddAction(self, action: ToastButton) -> None:
         """
@@ -271,33 +175,20 @@ class Toast:
 
         self.inputs.append(toast_input)
 
-    def SetCustomTimestamp(self, notificationTime: Optional[datetime.datetime]) -> None:
-        """
-        Sets a custom notification timestamp. If you don't provide a custom timestamp,
-        Windows uses the time that your notification was sent
-        """
-        self.timestamp = notificationTime
+    @property
+    def launch_action(self) -> Optional[str]:
+        """Protocol to launch when the toast is clicked"""
+        return self._launch_action
 
-    def SetExpirationTime(self, expirationTime: Optional[datetime.datetime]) -> None:
-        """
-        Sets a time for the toast to expire on in the action center. If it is on-screen, nothing will happen
-        """
-        self.expiration_time = expirationTime
+    @launch_action.setter
+    def launch_action(self, value: Optional[str]):
+        if value is None:
+            self._launch_action = None
+        else:
+            if not urllib.parse.urlparse(value).scheme:
+                warnings.warn(f"Ensure your launch action of {value} is of a proper protocol")
 
-    def SetSuppressPopup(self, suppressPopup: bool) -> None:
-        """
-        Sets whether to suppress the popup and instead immediately place it in the action center
-        """
-        self.suppress_popup = suppressPopup
-
-    def SetLaunchAction(self, launchAction: str) -> None:
-        """
-        Sets the protocol to launch when the toast is clicked
-        """
-        if not urllib.parse.urlparse(launchAction).scheme:
-            warnings.warn(f"Ensure your launch action of {launchAction} is a proper protocol")
-
-        self.launch_action = launchAction
+            self._launch_action = value
 
     def clone(self) -> Toast:
         """

--- a/src/windows_toasts/toast_document.py
+++ b/src/windows_toasts/toast_document.py
@@ -38,7 +38,7 @@ class ToastDocument:
         self.bindingNode = self.GetElementByTagName("binding")
 
         # Unclear whether this leads to issues regarding spacing
-        for i in range(len(toast.textFields)):
+        for i in range(len(toast.text_fields)):
             textElement = self.xmlDocument.create_element("text")
             # Needed for WindowsToaster
             self.SetAttribute(textElement, "id", str(i + 1))

--- a/src/windows_toasts/toasters.py
+++ b/src/windows_toasts/toasters.py
@@ -34,7 +34,7 @@ def _build_adaptable_data(toast: Toast) -> NotificationData:
     toast.updates += 1
     notificationData.sequence_number = toast.updates
 
-    for i, fieldContent in enumerate(toast.textFields):
+    for i, fieldContent in enumerate(toast.text_fields):
         if fieldContent is not None:
             notificationData.values[f"text{i + 1}"] = fieldContent
 
@@ -103,7 +103,7 @@ class BaseWindowsToaster:
         for image in toast.images:
             toastContent.AddImage(image)
 
-        for i, fieldContent in enumerate(toast.textFields):
+        for i, fieldContent in enumerate(toast.text_fields):
             if fieldContent is None:
                 continue
 
@@ -253,9 +253,9 @@ class WindowsToaster(BaseWindowsToaster):
         super().show_toast(toast)
 
     def _setup_toast(self, toast: Toast, dynamic: bool) -> ToastDocument:
-        for i, textField in enumerate(toast.textFields):
+        for i, textField in enumerate(toast.text_fields):
             if textField is None:
-                toast.textFields[i] = ""
+                toast.text_fields[i] = ""
 
         toastContent = super()._setup_toast(toast, dynamic)
         toastContent.SetAttribute(toastContent.bindingNode, "template", "ToastImageAndText04")

--- a/src/windows_toasts/toasters.py
+++ b/src/windows_toasts/toasters.py
@@ -103,15 +103,6 @@ class BaseWindowsToaster:
         for image in toast.images:
             toastContent.AddImage(image)
 
-        for i, fieldContent in enumerate(toast.text_fields):
-            if fieldContent is None:
-                continue
-
-            if dynamic:
-                toastContent.SetTextField(i)
-            else:
-                toastContent.SetTextFieldStatic(i, fieldContent)
-
         if toast.duration != ToastDuration.Default:
             toastContent.SetDuration(toast.duration)
 
@@ -252,12 +243,18 @@ class WindowsToaster(BaseWindowsToaster):
 
         super().show_toast(toast)
 
-    def _setup_toast(self, toast: Toast, dynamic: bool) -> ToastDocument:
-        for i, textField in enumerate(toast.text_fields):
-            if textField is None:
-                toast.text_fields[i] = ""
-
+    def _setup_toast(self, toast, dynamic) -> ToastDocument:
         toastContent = super()._setup_toast(toast, dynamic)
+
+        for i, fieldContent in enumerate(toast.text_fields):
+            if fieldContent is None:
+                fieldContent = ""
+
+            if dynamic:
+                toastContent.SetTextField(i)
+            else:
+                toastContent.SetTextFieldStatic(i, fieldContent)
+
         toastContent.SetAttribute(toastContent.bindingNode, "template", "ToastImageAndText04")
 
         return toastContent
@@ -285,6 +282,15 @@ class InteractableWindowsToaster(BaseWindowsToaster):
 
     def _setup_toast(self, toast, dynamic):
         toastContent = super()._setup_toast(toast, dynamic)
+
+        for i, fieldContent in enumerate(toast.text_fields):
+            if fieldContent is None:
+                continue
+
+            if dynamic:
+                toastContent.SetTextField(i)
+            else:
+                toastContent.SetTextFieldStatic(i, fieldContent)
 
         toastContent.SetAttribute(toastContent.bindingNode, "template", "ToastGeneric")
         toastNode = toastContent.GetElementByTagName("toast")

--- a/tests/test_toasts.py
+++ b/tests/test_toasts.py
@@ -11,8 +11,7 @@ def test_simple_toast():
 
     simpleToast = Toast()
 
-    simpleToast.SetFirstLine("Hello, World!")
-    simpleToast.SetSecondLine("Foobar")
+    simpleToast.text_fields = ["Hello, World!", "Foobar"]
 
     simpleToast.on_activated = lambda _: print("Toast clicked!")
     simpleToast.on_dismissed = lambda dismissedEventArgs: print(f"Toast dismissed! {dismissedEventArgs.reason}")
@@ -38,7 +37,7 @@ def test_interactable_toast(example_image_path):
     newInput = ToastInputTextBox("input", "Your input:", "Write your placeholder text here!")
     firstButton = ToastButton("First", "clicked=first", image=ToastImage(example_image_path), relatedInput=newInput)
     newToast = Toast(actions=(firstButton,))
-    newToast.SetFirstLine("Hello, interactable world!")
+    newToast.text_fields = ["Hello, interactable world!"]
 
     newToast.AddInput(newInput)
 
@@ -54,8 +53,8 @@ def test_audio_toast():
 
     toaster = WindowsToaster("Python")
 
-    originalToast = Toast(first_line="Ding ding!")
-    originalToast.SetAudio(ToastAudio(AudioSource.IM))
+    originalToast = Toast(["Ding ding!"])
+    originalToast.audio = ToastAudio(AudioSource.IM)
 
     toaster.show_toast(originalToast)
 
@@ -63,7 +62,7 @@ def test_audio_toast():
     silentToast = originalToast.clone()
     assert silentToast != "False EQ" and silentToast != originalToast
 
-    silentToast.SetFirstLine("Silence...")
+    silentToast.text_fields = ["Silence..."]
     silentToast.audio.silent = True
 
     toaster.show_toast(silentToast)
@@ -89,16 +88,17 @@ def test_errors_toast(example_image_path):
     )
 
     textToast = Toast()
-    textToast.SetFirstLine("Hello, World!")
+    textToast.text_fields = ["Hello, World!"]
 
     displayImage = ToastDisplayImage.fromPath(example_image_path)
 
-    with warns(UserWarning, match="is a proper protocol"):
-        textToast.SetLaunchAction("notanactualprotocol")
+    fakeProtocol = "notanactualprotocol"
+    with warns(UserWarning, match=f"Ensure your launch action of {fakeProtocol} is of a proper protocol"):
+        textToast.launch_action = fakeProtocol
 
-    assert textToast.textFields[0] == "Hello, World!"
+    assert textToast.text_fields[0] == "Hello, World!"
 
-    newToast = Toast(first_line="Hello, World!")
+    newToast = Toast(["Hello, World!"])
 
     with raises(InvalidImageException, match="could not be found"):
         _ = ToastImage(example_image_path.with_suffix(".nonexistant"))
@@ -140,9 +140,7 @@ def test_image_toast(example_image_path):
     toastDP = ToastDisplayImage(toastImage, altText="Windows logo", position=ToastImagePosition.Hero)
     newToast = Toast(images=(toastDP,))
 
-    newToast.SetFirstLine("Hello, World!")
-    newToast.SetSecondLine("Foo")
-    newToast.SetThirdLine("Bar")
+    newToast.text_fields = ["Hello, World!", "Foo", "Bar"]
 
     newToast.AddImage(ToastDisplayImage.fromPath(str(example_image_path), circleCrop=False))
 
@@ -154,8 +152,8 @@ def test_custom_timestamp_toast():
 
     from src.windows_toasts import Toast
 
-    newToast = Toast(first_line="This should display as being sent an hour ago")
-    newToast.SetCustomTimestamp(datetime.utcnow() - timedelta(hours=1))
+    newToast = Toast(["This should display as being sent an hour ago"])
+    newToast.timestamp = datetime.utcnow() - timedelta(hours=1)
 
     WindowsToaster("Python").show_toast(newToast)
 
@@ -180,7 +178,7 @@ def test_input_toast():
     newBoxInput.default_selection = None
     newToast.AddInput(newBoxInput)
 
-    newToast.SetFirstLine("You. Yes, you.")
+    newToast.text_fields = ["You. Yes, you."]
 
     InteractableWindowsToaster("Python").show_toast(newToast)
 
@@ -188,7 +186,7 @@ def test_input_toast():
 def test_custom_duration_toast():
     from src.windows_toasts import Toast, ToastDuration
 
-    newToast = Toast(duration=ToastDuration.Short, first_line="A short toast")
+    newToast = Toast(["A short toast"], duration=ToastDuration.Short)
     WindowsToaster("Python").show_toast(newToast)
 
 
@@ -196,8 +194,7 @@ def test_attribution_text_toast():
     from src.windows_toasts import Toast
 
     newToast = Toast()
-    newToast.SetFirstLine("Hello, World!")
-    newToast.SetSecondLine("Foobar")
+    newToast.text_fields = ["Hello, World!", "Foobar"]
 
     toaster = WindowsToaster("Python")
     toastContent = toaster._setup_toast(newToast, False)
@@ -209,8 +206,8 @@ def test_attribution_text_toast():
 def test_scenario_toast():
     from src.windows_toasts import Toast, ToastScenario
 
-    newToast = Toast(first_line="Very important toast!", second_line="Are you ready?", third_line="Here it comes!")
-    newToast.SetScenario(ToastScenario.Important)
+    newToast = Toast(["Very important toast!", "Are you ready?", "Here it comes!"])
+    newToast.scenario = ToastScenario.Important
 
     WindowsToaster("Python").show_toast(newToast)
 
@@ -221,14 +218,14 @@ def test_update_toast():
     toaster = WindowsToaster("Python")
 
     newToast = Toast()
-    newToast.SetFirstLine("Hello, World!")
+    newToast.text_fields = ["Hello, World!"]
 
     toaster.show_toast(newToast)
 
     import time
 
     time.sleep(0.5)
-    newToast.SetFirstLine("Goodbye, World!")
+    newToast.text_fields = ["Goodbye, World!"]
 
     toaster.update_toast(newToast)
 
@@ -259,7 +256,7 @@ def test_scheduled_toast(pytestconfig):
     progressBar = ToastProgressBar(
         "Preparing...", "Python 4 release", progress=0.5, progress_override="? millenniums remaining"
     )
-    newToast = Toast(progress_bar=progressBar, first_line="Incoming:")
+    newToast = Toast(progress_bar=progressBar, text_fields=["Incoming:"])
 
     # Branching
     clonedToast = newToast.clone()
@@ -289,13 +286,13 @@ def test_expiration_toasts():
     from src.windows_toasts import Toast
 
     expirationTime = datetime.now() + timedelta(minutes=1)
-    newToast = Toast(first_line="Hello, World!", group="Test Toasts", expiration_time=expirationTime)
+    newToast = Toast(["Hello, World!"], group="Test Toasts", expiration_time=expirationTime)
     WindowsToaster("Python").show_toast(newToast)
 
 
 def test_protocol_launch():
     from src.windows_toasts import Toast, ToastButton
 
-    newToast = Toast(first_line="Click on me to open google.com", launch_action="https://google.com")
+    newToast = Toast(["Click on me to open google.com"], launch_action="https://google.com")
     newToast.AddAction(ToastButton("Launch calculator", launch="calculator://"))
     InteractableWindowsToaster("Python").show_toast(newToast)

--- a/tests/test_toasts.py
+++ b/tests/test_toasts.py
@@ -20,6 +20,15 @@ def test_simple_toast():
     WindowsToaster("Python").show_toast(simpleToast)
 
 
+def test_multiline_toast():
+    from src.windows_toasts import Toast
+
+    multilineToast = Toast(["Hello, World!", None, "Goodbye, World!"])
+
+    WindowsToaster("Python").show_toast(multilineToast)
+    InteractableWindowsToaster("Python").show_toast(multilineToast)
+
+
 def test_interactable_toast(example_image_path):
     from src.windows_toasts import (
         Toast,


### PR DESCRIPTION
BREAKING CHANGE: All the SetX methods have been removed

- Toast.first_line/.second_line/.third_line reworked into a text_fields list
- Instead of a multitude of SetX methods, the attributes should now be modified directly
- Updated documentation to fit this