### PR TITLE
fix(toasters): correct typo that led to error with clear_toasts()

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,6 @@
 1.0.1 (2023-09-11)
 ==================
-- Fixed AttributeError when calling WindowsToaster.clear_toasts()
+- Fixed AttributeError when calling WindowsToaster.clear_toasts() (#96)
 - unschedule_toast() now raise a ToastNotFoundError exception if the toast could not be found instead of warning (#97)
 
 1.0.0 (2023-08-14)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,5 +1,6 @@
 1.0.1 (2023-09-11)
 ==================
+- Fixed AttributeError when calling WindowsToaster.clear_toasts()
 - unschedule_toast() now raise a ToastNotFoundError exception if the toast could not be found instead of warning (#97)
 
 1.0.0 (2023-08-14)

--- a/src/windows_toasts/toasters.py
+++ b/src/windows_toasts/toasters.py
@@ -222,7 +222,7 @@ class WindowsToaster(BaseWindowsToaster):
 
     def __init__(self, applicationText: str):
         super().__init__(applicationText)
-        self.notifierAUMI = None
+        self.notifierAUMID = None
         self.toastNotifier = ToastNotificationManager.create_toast_notifier(applicationText)
 
     def show_toast(self, toast: Toast) -> None:  # pragma: no cover


### PR DESCRIPTION
"notifierAUMI" -> "notifierAUMID". Resolves #95.