### PR TITLE
docs: add documentation for exceptions on rtd.io

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -58,6 +58,7 @@ Contents
    user/toast
    user/audio
    user/wrappers
+   user/exceptions
 
 .. toctree::
    :maxdepth: 1

--- a/docs/user/exceptions.rst
+++ b/docs/user/exceptions.rst
@@ -1,0 +1,14 @@
+Exceptions
+==========
+
+Classes
+-------
+
+.. autosummary::
+    windows_toasts.exceptions.InvalidImageException
+    windows_toasts.exceptions.ToastNotFoundError
+
+API
+---
+
+.. automodule:: windows_toasts.exceptions

--- a/docs/user/wrappers.rst
+++ b/docs/user/wrappers.rst
@@ -24,6 +24,11 @@ API
 ---
 
 .. automodule:: windows_toasts.wrappers
+    :exclude-members: ToastImage
+
+    .. autoclass:: windows_toasts.wrappers.ToastImage
+
+        .. automethod:: __init__
 
 ..
     This will probably go into another file soon

--- a/src/windows_toasts/wrappers.py
+++ b/src/windows_toasts/wrappers.py
@@ -86,14 +86,14 @@ class ToastImage:
 
     def __init__(self, imagePath: Union[str, PathLike]):
         """
-        Initialise an :class:`ToastImage` class to use in certain classes
+        Initialise an :class:`ToastImage` class to use in certain classes.
         Online images are supported only in packaged apps that have the internet capability in their manifest.
         Unpackaged apps don't support http images; you must download the image to your local app data,
         and reference it locally.
 
         :param imagePath: The path to an image file
         :type imagePath: Union[str, PathLike]
-        :raises: ValueError: If the path to an online image is supplied
+        :raises: InvalidImageException: If the path to an online image is supplied
         """
         if isinstance(imagePath, str) and urlparse(imagePath).scheme in ("http", "https"):
             raise InvalidImageException("Online images are not supported")


### PR DESCRIPTION
- Added exceptions file to rtd.io
- Use InvalidImageException instead of ValueError in documentation for ToastImage.__init__()
- Include __init__ method in ToastImage API documentation