### PR TITLE
Bug fix: Unable to display images when the path contains Chinese char…

### DIFF
--- a/src/windows_toasts/wrappers.py
+++ b/src/windows_toasts/wrappers.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import abc
+import urllib
 from dataclasses import dataclass
 from enum import Enum
 from os import PathLike
@@ -103,7 +104,7 @@ class ToastImage:
         if not imagePath.exists():
             raise InvalidImageException(f"Image with path '{imagePath}' could not be found")
 
-        self.path = imagePath.as_uri()
+        self.path = urllib.parse.unquote(imagePath.as_uri())
 
 
 @dataclass


### PR DESCRIPTION
Using URL encoding will cause Chinese characters to display as garbled text, making it impossible to correctly display images with Chinese file paths. By using the `urllib.parse.unquote()` method to restore the garbled URL, the Chinese characters can be displayed properly.