### PR TITLE
Convert image paths to absolute before converting to URI

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 1.0.2 (2023-12-31)
 ===================
 - Unquote image paths when the path contains characters that were escaped (#111)
+- Convert image paths to absolute before converting to URI (#112)
 
 1.0.1 (2023-09-11)
 ==================

--- a/src/windows_toasts/wrappers.py
+++ b/src/windows_toasts/wrappers.py
@@ -104,7 +104,7 @@ class ToastImage:
         if not imagePath.exists():
             raise InvalidImageException(f"Image with path '{imagePath}' could not be found")
 
-        self.path = urllib.parse.unquote(imagePath.as_uri())
+        self.path = urllib.parse.unquote(imagePath.absolute().as_uri())
 
 
 @dataclass


### PR DESCRIPTION
This throws an exception in Path.as_uri() if it isn't done by then anyways