### PR TITLE
refactor: replace toasts_winrt with winrt-Namespace packages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ["3.8", "3.9", "3.10", "3.11"]
+        python-version: ["3.9", "3.10", "3.11", "3.12"]
         os: [windows-latest]
 
     steps:

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+Unversioned
+===========
+- Replaced toasts_winrt with winrt-Namespace packages (#113)
+
 1.0.2 (2023-12-31)
 ===================
 - Unquote image paths when the path contains characters that were escaped (#111)

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,7 @@
 Unversioned
 ===========
 - Replaced toasts_winrt with winrt-Namespace packages (#113)
+- Dropped Python 3.8 support (#113)
 
 1.0.2 (2023-12-31)
 ===================

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -46,7 +46,7 @@ extensions = [
 templates_path = ["_templates"]
 exclude_patterns = ["_build", "Thumbs.db", ".DS_Store"]
 
-autodoc_mock_imports = ["toasts_winrt"]
+autodoc_mock_imports = ["winrt"]
 autodoc_default_options = {"members": True, "member-order": "bysource", "undoc-members": True}
 
 # -- Options for HTML output -------------------------------------------------

--- a/docs/getting_started.rst
+++ b/docs/getting_started.rst
@@ -4,7 +4,7 @@ Getting started
 Installing Windows-Toasts
 -------------------------
 
-Windows-Toasts requires Python 3.8 or later, and supports Windows 10 and 11.
+The latest version of Windows-Toasts requires Python 3.9 or later, and supports Windows 10 and 11.
 
 It can be installed using pip:
 

--- a/setup.py
+++ b/setup.py
@@ -3,10 +3,10 @@ from setuptools import setup
 packages = ["windows_toasts", "scripts"]
 
 requires = [
-    "winrt-Windows.Data.Xml.Dom==2.0.0b2",
-    "winrt-Windows.Foundation==2.0.0b2",
-    "winrt-Windows.Foundation.Collections==2.0.0b2",
-    "winrt-Windows.UI.Notifications==2.0.0b2",
+    "winrt-Windows.Data.Xml.Dom<=2.0.0b2",
+    "winrt-Windows.Foundation<=2.0.0b2",
+    "winrt-Windows.Foundation.Collections<=2.0.0b2",
+    "winrt-Windows.UI.Notifications<=2.0.0b2",
 ]
 
 with open("README.md", "r", encoding="utf-8") as f:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,12 @@ from setuptools import setup
 
 packages = ["windows_toasts", "scripts"]
 
-requires = ["toasts-winrt==1.0.0"]
+requires = [
+    "winrt-Windows.Data.Xml.Dom==2.0.0b2",
+    "winrt-Windows.Foundation==2.0.0b2",
+    "winrt-Windows.Foundation.Collections==2.0.0b2",
+    "winrt-Windows.UI.Notifications==2.0.0b2",
+]
 
 with open("README.md", "r", encoding="utf-8") as f:
     readme = f.read()

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,7 @@ from setuptools import setup
 packages = ["windows_toasts", "scripts"]
 
 requires = [
+    "winrt-runtime<=2.0.0b2",
     "winrt-Windows.Data.Xml.Dom<=2.0.0b2",
     "winrt-Windows.Foundation<=2.0.0b2",
     "winrt-Windows.Foundation.Collections<=2.0.0b2",
@@ -30,14 +31,13 @@ setup(
     package_data={"": ["LICENSE"], "windows_toasts": ["py.typed"]},
     include_package_data=True,
     entry_points={"console_scripts": ["register_hkey_aumid = scripts.register_hkey_aumid:main"]},
-    python_requires=">=3.8",
+    python_requires=">=3.9",
     install_requires=requires,
     license=about["__license__"],
     zip_safe=False,
     classifiers=[
         "Development Status :: 4 - Beta",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",

--- a/src/windows_toasts/events.py
+++ b/src/windows_toasts/events.py
@@ -3,9 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Dict, Optional
 
-from toasts_winrt import system
-from toasts_winrt.windows.foundation import IPropertyValue
-from toasts_winrt.windows.ui.notifications import (  # noqa: F401
+from winrt import system
+from winrt.windows.foundation import IPropertyValue
+from winrt.windows.ui.notifications import (  # noqa: F401
     ToastActivatedEventArgs as WinRtToastActivatedEventArgs,
     ToastDismissalReason,
     ToastDismissedEventArgs,

--- a/src/windows_toasts/toast.py
+++ b/src/windows_toasts/toast.py
@@ -8,7 +8,7 @@ import warnings
 from collections.abc import Iterable
 from typing import Callable, Literal, Optional, TypeVar, Union
 
-from toasts_winrt.windows.ui.notifications import ToastDismissedEventArgs, ToastFailedEventArgs
+from winrt.windows.ui.notifications import ToastDismissedEventArgs, ToastFailedEventArgs
 
 from .events import ToastActivatedEventArgs
 from .toast_audio import ToastAudio

--- a/src/windows_toasts/toast_document.py
+++ b/src/windows_toasts/toast_document.py
@@ -1,7 +1,7 @@
 import datetime
 from typing import Optional, TypeVar, Union
 
-from toasts_winrt.windows.data.xml.dom import IXmlNode, XmlDocument, XmlElement
+from winrt.windows.data.xml.dom import IXmlNode, XmlDocument, XmlElement
 
 from .toast import Toast
 from .toast_audio import ToastAudio

--- a/src/windows_toasts/toasters.py
+++ b/src/windows_toasts/toasters.py
@@ -2,7 +2,7 @@ import warnings
 from datetime import datetime
 from typing import Optional, TypeVar
 
-from toasts_winrt.windows.ui.notifications import (
+from winrt.windows.ui.notifications import (
     NotificationData,
     NotificationUpdateResult,
     ScheduledToastNotification,

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,9 +11,9 @@ def real_run_fixture(pytestconfig) -> Iterator[None]:
     if pytestconfig.getoption("real_run"):
         yield
     else:
-        with patch("toasts_winrt.windows.ui.notifications.ToastNotificationManager.create_toast_notifier"), patch(
-            "toasts_winrt.windows.ui.notifications.ToastNotifier.show"
-        ), patch("toasts_winrt.windows.ui.notifications.ToastNotificationHistory.clear"):
+        with patch("winrt.windows.ui.notifications.ToastNotificationManager.create_toast_notifier"), patch(
+            "winrt.windows.ui.notifications.ToastNotifier.show"
+        ), patch("winrt.windows.ui.notifications.ToastNotificationHistory.clear"):
             yield
 
 

--- a/tests/test_toasts.py
+++ b/tests/test_toasts.py
@@ -182,7 +182,7 @@ def test_custom_duration_toast():
 
 
 def test_attribution_text_toast():
-    from toasts_winrt.windows.ui.notifications import ToastNotification
+    from winrt.windows.ui.notifications import ToastNotification
 
     newToast = Toast()
     newToast.text_fields = ["Hello, World!", "Foobar"]


### PR DESCRIPTION
Better maintained by third party and resolves the concern that made me create the first party package to begin with. Closes #106