### PR TITLE
Allow newer versions of winrt

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,3 +1,7 @@
+1.1.1 (2024-05-19)
+==================
+- Added support for winrt v2.0.1 (#138)
+
 1.1.0 (2024-02-13)
 ==================
 - Importing the module now throws an exception if the Windows version is unsupported (#122)

--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,11 @@ from setuptools import setup
 packages = ["windows_toasts", "scripts"]
 
 requires = [
-    "winrt-runtime>=2.0.0b2",
-    "winrt-Windows.Data.Xml.Dom>=2.0.0b2",
-    "winrt-Windows.Foundation>=2.0.0b2",
-    "winrt-Windows.Foundation.Collections>=2.0.0b2",
-    "winrt-Windows.UI.Notifications>=2.0.0b2",
+    "winrt-runtime<=2.0.1",
+    "winrt-Windows.Data.Xml.Dom<=2.0.1",
+    "winrt-Windows.Foundation<=2.0.1",
+    "winrt-Windows.Foundation.Collections<=2.0.1",
+    "winrt-Windows.UI.Notifications<=2.0.1",
 ]
 
 with open("README.md", "r", encoding="utf-8") as f:

--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,11 @@ from setuptools import setup
 packages = ["windows_toasts", "scripts"]
 
 requires = [
-    "winrt-runtime<=2.0.0b2",
-    "winrt-Windows.Data.Xml.Dom<=2.0.0b2",
-    "winrt-Windows.Foundation<=2.0.0b2",
-    "winrt-Windows.Foundation.Collections<=2.0.0b2",
-    "winrt-Windows.UI.Notifications<=2.0.0b2",
+    "winrt-runtime>=2.0.0b2",
+    "winrt-Windows.Data.Xml.Dom>=2.0.0b2",
+    "winrt-Windows.Foundation>=2.0.0b2",
+    "winrt-Windows.Foundation.Collections>=2.0.0b2",
+    "winrt-Windows.UI.Notifications>=2.0.0b2",
 ]
 
 with open("README.md", "r", encoding="utf-8") as f:


### PR DESCRIPTION
Due to the current limitations on `winrt` of `windows-toasts`, we can't use newer versions of the `winrt` packages.
Pip errors out:
```
ERROR: Cannot install windows-toasts==1.1.0 and winrt-runtime==2.0.1 because these package versions have conflicting dependencies.

The conflict is caused by:
    The user requested winrt-runtime==2.0.1
    windows-toasts 1.1.0 depends on winrt-runtime<=2.0.0b2

To fix this you could try to:
1. loosen the range of package versions you've specified
2. remove package versions to allow pip attempt to solve the dependency conflict
```