### PR TITLE
tests: improve typing

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,3 +17,6 @@ line_length = 120
 
 [tool.pytest.ini_options]
 pythonpath = ["src"]
+
+[tool.mypy]
+exclude = ["build/", "main.py"]

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ requires = [
 with open("README.md", "r", encoding="utf-8") as f:
     readme = f.read()
 
-about = {}
+about: dict[str, str] = {}
 with open("src/windows_toasts/_version.py", "r") as f:
     exec(f.read(), None, about)
 

--- a/src/windows_toasts/toast.py
+++ b/src/windows_toasts/toast.py
@@ -6,7 +6,7 @@ import urllib.parse
 import uuid
 import warnings
 from collections.abc import Iterable
-from typing import Callable, Literal, Optional, TypeVar, Union
+from typing import Callable, Literal, Optional, Union
 
 from winrt.windows.ui.notifications import ToastDismissedEventArgs, ToastFailedEventArgs
 
@@ -23,7 +23,7 @@ from .wrappers import (
     ToastSystemButton,
 )
 
-ToastInput = TypeVar("ToastInput", ToastInputTextBox, ToastInputSelectionBox)
+ToastInput = Union[ToastInputTextBox, ToastInputSelectionBox]
 
 
 class Toast:
@@ -68,7 +68,7 @@ class Toast:
 
     def __init__(
         self,
-        text_fields: Union[list[Optional[str]], tuple[Optional[str]], set[Optional[str]]] = None,
+        text_fields: Union[None, list[Optional[str]], tuple[Optional[str]], set[Optional[str]]] = None,
         audio: Optional[ToastAudio] = None,
         duration: ToastDuration = ToastDuration.Default,
         expiration_time: Optional[datetime.datetime] = None,

--- a/src/windows_toasts/toast_document.py
+++ b/src/windows_toasts/toast_document.py
@@ -1,5 +1,5 @@
 import datetime
-from typing import Optional, TypeVar, Union
+from typing import Union
 
 from winrt.windows.data.xml.dom import IXmlNode, XmlDocument, XmlElement
 
@@ -18,7 +18,7 @@ from .wrappers import (
     ToastSystemButtonAction,
 )
 
-IXmlType = TypeVar("IXmlType", IXmlNode, XmlElement)
+IXmlType = Union[IXmlNode, XmlElement]
 
 
 class ToastDocument:
@@ -69,7 +69,7 @@ class ToastDocument:
         """
         return nodeAttribute.attributes.get_named_item(attributeName).inner_text
 
-    def GetElementByTagName(self, tagName: str) -> Optional[IXmlType]:
+    def GetElementByTagName(self, tagName: str) -> IXmlType:
         """
         Helper function to get the first element by its tag name
 
@@ -220,18 +220,16 @@ class ToastDocument:
 
         :type toastInput: Union[ToastInputTextBox, ToastInputSelectionBox]
         """
-        isTextBox = isinstance(toastInput, ToastInputTextBox)
-
         self._inputFields += 1
         inputNode = self.xmlDocument.create_element("input")
         self.SetAttribute(inputNode, "id", toastInput.input_id)
         self.SetAttribute(inputNode, "title", toastInput.caption)
 
-        if isTextBox:
+        if isinstance(toastInput, ToastInputTextBox):
             self.SetAttribute(inputNode, "type", "text")
             # noinspection PyUnresolvedReferences
             self.SetAttribute(inputNode, "placeHolderContent", toastInput.placeholder)
-        else:
+        elif isinstance(toastInput, ToastInputSelectionBox):
             self.SetAttribute(inputNode, "type", "selection")
             if toastInput.default_selection is not None:
                 self.SetAttribute(inputNode, "defaultInput", toastInput.default_selection.selection_id)


### PR DESCRIPTION
- Corrected use of TypeVar (should be TypeAlias but only supported in 3.10+)
- Made text fields optional
- Check toastInput type more accurately