### PR TITLE
chore: soften winrt packages version specification

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,7 +1,8 @@
-1.2.0 (TBD)
+1.2.0 (2024-06-30)
 ===========
 - Implement removing toasts and toast groups (#145)
   - See `'removing toasts' <https://windows-toasts.readthedocs.io/en/latest/advanced_usage.html#removing-toasts>`_ for an example.
+- Relax winrt package versioning requirements to support 2.x (#153)
 
 1.1.1 (2024-05-19)
 ==================

--- a/setup.py
+++ b/setup.py
@@ -3,11 +3,11 @@ from setuptools import setup
 packages = ["windows_toasts", "scripts"]
 
 requires = [
-    "winrt-runtime<=2.0.1",
-    "winrt-Windows.Data.Xml.Dom<=2.0.1",
-    "winrt-Windows.Foundation<=2.0.1",
-    "winrt-Windows.Foundation.Collections<=2.0.1",
-    "winrt-Windows.UI.Notifications<=2.0.1",
+    "winrt-runtime~=2.0",
+    "winrt-Windows.Data.Xml.Dom~=2.0",
+    "winrt-Windows.Foundation~=2.0",
+    "winrt-Windows.Foundation.Collections~=2.0",
+    "winrt-Windows.UI.Notifications~=2.0",
 ]
 
 with open("README.md", "r", encoding="utf-8") as f:


### PR DESCRIPTION
Should now support version 2.0 up to 3.0, excluding. Resolves #152